### PR TITLE
Fixed Sprite image

### DIFF
--- a/projects/cultivator/sprite/index.html
+++ b/projects/cultivator/sprite/index.html
@@ -25,11 +25,7 @@
 		outline: none;
 		background: url('./grid.png') repeat repeat;
 	}
-	#tool article figure img {
-		position: absolute;
-		top: 0px;
-		left: 0px;
-	}
+
 	</style>
 </head>
 <body>


### PR DESCRIPTION
With `position: absolute` the parent element couldn't scale automatically